### PR TITLE
Make notification_channel optional in NixOS module

### DIFF
--- a/contrib/nixos/module.nix
+++ b/contrib/nixos/module.nix
@@ -96,7 +96,7 @@ let
       secret = ${cfg.mastodon.secret}
       token = ${cfg.mastodon.token}
       base_url = ${cfg.mastodon.baseUrl}
-      notification_channel = ${cfg.mastodon.notificationChannel} 
+      notification_channel = ${toString cfg.mastodon.notificationChannel}
     '';
 
     cfg = config.services.troet;
@@ -151,7 +151,8 @@ in {
     };
 
     mastodon.notificationChannel = mkOption {
-      type = types.str;
+      default = null;
+      type = types.nullOr types.str;
     };
 
   };


### PR DESCRIPTION
This commit adds support to make the notification_channel in the NixOS module optional. This was previously not supported and led to not so happy users.