### PR TITLE
Add boost feature and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Given the bot code of the toot it will try to delete the toot. Only works on too
 If given a permalink to a toot it will show this toot in IRC and assign a bot code to it. Afterwards the bot can be used to reply to it.
 In the Mastodon UI you can get the permalink of a toot by clicking on the timestamp. If it contains `/web/` it is **not** the permalink.
 
+``` .fav ```
+
+Favourite a toot using the ID received via `.search`. Undo by running the command again.
+
+``` .boost ```
+
+Boost a toot using the ID received via `.search`. Undo by running the command again.
+
 ``` .listedtoot .lt ```
 
 To prevent potential spam from the bot to be visible on the Mastodon instances public timeline all normal toots and replies are sent with visibility set to unlisted.
@@ -85,5 +93,3 @@ Stops all currently requsted but unposted toots (used in delayed mode)
 - At the moment this code painfully ignores any kind of ratelimiting
   - If the size of the messageCache is too big (i.e.: close to 300) this could be a problem while starting the bot
     - Toots need to be reloaded due to message structure cannot be json serialized easily (because of datetime types) (i.e. I am lazy and should work on a workaround)
-- Add Feature for sharing toots (Twitter "retweet" equivalent)
-

--- a/sopel_modules/troet/troet.py
+++ b/sopel_modules/troet/troet.py
@@ -225,6 +225,29 @@ def fav(bot: SopelWrapper, trigger: Trigger):
     messageCache[key] = toot
 
 
+@plugin.command("boost")
+@plugin.require_chanmsg("Only available in Channel")
+def boost(bot: SopelWrapper, trigger: Trigger):
+    key = trigger.args[1].split(" ", 1)[1]
+    config: MastodonSection = bot.settings.mastodon
+    client = config.getMastodonClient()
+    messageCache = config.getMessageCache()
+    if key not in messageCache:
+        bot.notice(PLUGIN_OUTPUT_PREFIX + f"Unknown reference: {key}")
+        return
+    if not messageCache[key]["reblogged"]:
+        toot = client.status_reblog(messageCache[key]["id"])
+        bot.notice(
+            PLUGIN_OUTPUT_PREFIX + f"Boosted: [{key}] {messageCache[key]['url']}"
+        )
+    else:
+        toot = client.status_unreblog(messageCache[key]["id"])
+        bot.notice(
+            PLUGIN_OUTPUT_PREFIX + f"Unboosted: [{key}] {messageCache[key]['url']}"
+        )
+    messageCache[key] = toot
+
+
 @plugin.command("cancel")
 @plugin.require_chanmsg("Only available in Channel")
 @plugin.require_privilege(plugin.OP)


### PR DESCRIPTION
This commit adds the boost feature for reblogging toots.

Also, documentation is added for `.boost` and `.fav`.

The mention under TODO is removed.